### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/katapyooon/reptionary/security/code-scanning/1](https://github.com/katapyooon/reptionary/security/code-scanning/1)

To address the issue, set explicit `permissions` for the workflow at the root level. This will apply the permissions to all jobs within the workflow unless overridden within individual jobs. The recommended minimum permissions are `contents: read`, which allows the workflow to access repository contents while restricting write access. Additional permissions, such as `pull-requests: write`, should be added only if required by specific actions in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
